### PR TITLE
Fix for Linux

### DIFF
--- a/bd-scss.js
+++ b/bd-scss.js
@@ -54,7 +54,13 @@ prog
 			process.exit(1);
 		}
 
-		const themesFolder = bdFolder || path.join(dataFolder, 'BetterDiscord', 'themes');
+		let themesFolder = bdFolder || path.join(dataFolder, "BetterDiscord");
+		// Makes sure that all folders go to the /themes folder
+        	themesFolder = path.join(themesFolder, "themes");
+		// If a user puts ~ it will change to the actual home folder
+        	if (themesFolder[0] == "~") {
+            		themesFolder = process.env.HOME + themesFolder.substring(1);
+        	}
 
 		if (!fs.existsSync(themesFolder)) {
 			console.log(chalk.redBright.bold('[ERROR]') + ' Directory does not exist: ' + chalk.yellow('`' + themesFolder + '`'));

--- a/compiler.js
+++ b/compiler.js
@@ -57,7 +57,7 @@ export default async(options, meta = false) => {
 	// Write file to disk.
 	try {
 		fs.writeFileSync(typeof options.output === 'string' ? options.output : path.join(...options.output), generatedFile);
-		console.log(`${chalk.greenBright.bold('[SUCCESS]')} Successfully built ${chalk.yellow(`\`${options.target.join('/')}\``)} to ${chalk.yellow(`\`${options.output.join('\\')}\``)}`);
+		console.log(`${chalk.greenBright.bold('[SUCCESS]')} Successfully built ${chalk.yellow(`\`${options.target.join('/')}\``)} to ${chalk.yellow(`\`${options.output.join(process.env.APPDATA ? "\\" : "/")}\``)}`);
 	} catch (error) {
 		console.log(chalk.redBright.bold('[ERROR]'),	error);
 	}


### PR DESCRIPTION
- Changes some `\\` into `/` when printing out the filepath (this mostly just bothered me)
- Adds proper compatibility for Linux (and most likely macOS) by converting an inputted `~` at the start of a filepath into `/home/alli`