### PR TITLE
Allow using a absolute path for the dev output folder

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,7 +1,12 @@
 import { getConfig, getDataFolder } from './utils.js';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 const config = await getConfig();
-const dataFolder = getDataFolder();
+//Check for a absolute path given to the dev folder to suppress missing folder messages
+//because if we supplied a absolute path we are explicitly using a nonstandard setup so straight dir existence verification is preferred
+const devOutput = config?.dev?.output;
+const dataFolder = path.isAbsolute(devOutput) && fs.existsSync(devOutput) ? devOutput : getDataFolder();
 
 export const DEFAULTS = {
 	dev: {


### PR DESCRIPTION
One mayor annoyance with contributing to your themes is that it doesnt support anything but default betterdiscord installations, given how varied they can be on linux and alternatives like vencorcd existing i added some simple support for supplying a absolute path to anywhere you desire.